### PR TITLE
Provide an OSGI friendly artifact

### DIFF
--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -64,14 +64,31 @@
         <version>2.3.2</version>
         <configuration>
           <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true
-              </addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true
-              </addDefaultSpecificationEntries>
-            </manifest>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Require-Bundle></Require-Bundle>
+            <Export-Package>!.,com.github.kevinsawicki.http</Export-Package>
+            <Bundle-RequiredExecutionEnvironment>J2SE-1.5</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
With a valid OSGI MANIFEST.MF your library could be consumed and used for example by Eclipse plugins using Tycho as build system.
