### PR TITLE
Improve exception message when setting request headers after request data

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -1971,6 +1971,9 @@ public class HttpRequest {
    * @return this request
    */
   public HttpRequest header(final String name, final String value) {
+    if (form) {
+      throw new IllegalStateException("Headers must be declared before form data");
+    }
     getConnection().setRequestProperty(name, value);
     return this;
   }


### PR DESCRIPTION
The following code is not allowed by java.net.HttpURLConnection:
HttpRequest.post("<url>").form(dataMap).header("foo", "bar");

An IllegalStateException is thrown with the message "Already connected" because headers must be set before form data. The correct code is:
 HttpRequest.post("<url>").header("foo", "bar").form(dataMap);

It's usually not trivial to understand the root problem. This pull request aims to provide a better and clear message: "Headers must be declared before form data".

Note that the unit tests have been refactored in order to use the JUnit rule "ExpectedException" instead of the @Test parameter "expected". It allows to verify exception message.