### PR TITLE
Fix HttpRequest.followRedirects use of static setter

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -3129,7 +3129,7 @@ public class HttpRequest {
    * @return this request
    */
   public HttpRequest followRedirects(final boolean followRedirects) {
-    getConnection().setFollowRedirects(followRedirects);
+    getConnection().setInstanceFollowRedirects(followRedirects);
     return this;
   }
 }


### PR DESCRIPTION
Should alter the instance and not use the static default setter.
