### PR TITLE
Read Interrupt Timeout

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -906,6 +906,8 @@ public class HttpRequest {
     return result.toString();
   }
 
+  private int readInterruptTimeout;
+
   /**
    * Start a 'GET' request to the given URL
    *
@@ -1762,18 +1764,18 @@ public class HttpRequest {
    * @throws HttpRequestException
    */
   public InputStream stream() throws HttpRequestException {
-    InputStream stream;
+    InputStream stream = null;
     if (code() < HTTP_BAD_REQUEST)
       try {
-        stream = getConnection().getInputStream();
+        stream = getTimedOutInputStream();
       } catch (IOException e) {
         throw new HttpRequestException(e);
       }
     else {
-      stream = getConnection().getErrorStream();
+      stream = getTimedOutErrorStream();
       if (stream == null)
         try {
-          stream = getConnection().getInputStream();
+          stream = getTimedOutInputStream();
         } catch (IOException e) {
           throw new HttpRequestException(e);
         }
@@ -1787,6 +1789,43 @@ public class HttpRequest {
       } catch (IOException e) {
         throw new HttpRequestException(e);
       }
+  }
+
+  private InputStream getTimedOutInputStream() throws IOException {
+    InputStream stream = getConnection().getInputStream();
+    setReadInterruptTimerIfNeeded(stream);
+    return stream;
+  }
+
+  private InputStream getTimedOutErrorStream() {
+    InputStream stream = getConnection().getErrorStream();
+    setReadInterruptTimerIfNeeded(stream);
+    return stream;
+  }
+
+  private void setReadInterruptTimerIfNeeded(InputStream stream) {
+    if (readInterruptTimeout > 0 && stream != null) {
+      System.out.println("TimeoutLogs set " + getConnection().hashCode());
+      disconnectIn(readInterruptTimeout, stream, getConnection());
+    }
+  }
+
+  private void disconnectIn(int duration, final InputStream stream, final HttpURLConnection connection) {
+      Timer timer = new Timer();
+      timer.schedule(new TimerTask() {
+        @Override
+        public void run() {
+            try {
+                System.out.println("TimeoutLogs closing stream " + getConnection().hashCode());
+                stream.close();
+            } catch (IOException ignored) {
+                ignored.printStackTrace();
+            } finally {
+                System.out.println("TimeoutLogs disconnect " + getConnection().hashCode());
+                connection.disconnect();
+            }
+        }
+      }, duration);
   }
 
   /**
@@ -1953,6 +1992,17 @@ public class HttpRequest {
   }
 
   /**
+   * Set read interruption timeout on connection to given value
+   *
+   * @param timeout
+   * @return this request
+   */
+  public HttpRequest readInteruptTimeout(final int timeout) {
+    this.readInterruptTimeout = timeout;
+    return this;
+  }
+
+  /**
    * Set connect timeout on connection to given value
    *
    * @param timeout
@@ -1961,6 +2011,10 @@ public class HttpRequest {
   public HttpRequest connectTimeout(final int timeout) {
     getConnection().setConnectTimeout(timeout);
     return this;
+  }
+
+  public int getReadInteruptTimeout() {
+    return readInterruptTimeout;
   }
 
   /**

--- a/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
+++ b/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
@@ -176,6 +176,8 @@ public class HttpRequestTest extends ServerTestCase {
         .getReadTimeout());
     assertEquals(50000, request.connectTimeout(50000).getConnection()
         .getConnectTimeout());
+    assertEquals(90000, request.readInteruptTimeout(90000)
+        .getReadInteruptTimeout());
     assertEquals(2500, request.bufferSize(2500).bufferSize());
     assertFalse(request.ignoreCloseExceptions(false).ignoreCloseExceptions());
     assertFalse(request.useCaches(false).getConnection().getUseCaches());


### PR DESCRIPTION
Adds a forced timeout if the read takes too long even if the read has already started. Prevents endless wait on a defective server if a crash
occurs in the middle of a read
