### PR TITLE
Add json method to allow posting stringified json contents

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -3184,7 +3184,7 @@ public class HttpRequest {
    * @return this request
    * @throws HttpRequestException
    */
-  public HttpRequest json(final String jsonString) {
+  public HttpRequest json(final CharSequence jsonString) {
     contentType(CONTENT_TYPE_JSON);
     send(jsonString);
     return this;

--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -3184,15 +3184,9 @@ public class HttpRequest {
    * @return this request
    * @throws HttpRequestException
    */
-  public HttpRequest json(final String jsonString)
-      throws HttpRequestException {
+  public HttpRequest json(final String jsonString) {
     contentType(CONTENT_TYPE_JSON);
-    try {
-      openOutput();
-      output.write(jsonString);
-    } catch (IOException e) {
-      throw new HttpRequestException(e);
-    }
+    send(jsonString);
     return this;
   }
 

--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -3178,6 +3178,25 @@ public class HttpRequest {
   }
 
   /**
+   * Write the json string
+   *
+   * @param jsonString
+   * @return this request
+   * @throws HttpRequestException
+   */
+  public HttpRequest json(final String jsonString)
+      throws HttpRequestException {
+    contentType(CONTENT_TYPE_JSON);
+    try {
+      openOutput();
+      output.write(jsonString);
+    } catch (IOException e) {
+      throw new HttpRequestException(e);
+    }
+    return this;
+  }
+
+  /**
    * Configure HTTPS connection to trust all certificates
    * <p>
    * This method does nothing if the current request is not a HTTPS request

--- a/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
+++ b/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
@@ -839,6 +839,31 @@ public class HttpRequestTest extends ServerTestCase {
   }
 
   /**
+   * Make a post of json data
+   *
+   * @throws Exception
+   */
+  @Test
+  public void postJson() throws Exception {
+    final AtomicReference<String> body = new AtomicReference<String>();
+    final AtomicReference<String> contentType = new AtomicReference<String>();
+    handler = new RequestHandler() {
+
+      @Override
+      public void handle(Request request, HttpServletResponse response) {
+        body.set(new String(read()));
+        contentType.set(request.getContentType());
+        response.setStatus(HTTP_OK);
+      }
+    };
+    String jsonString = "{\"name\":\"user\",\"number\":\"1001\"}";
+    int code = post(url).json(jsonString).code();
+    assertEquals(HTTP_OK, code);
+    assertEquals(jsonString, body.get());
+    assertEquals("application/json", contentType.get());
+  }
+
+  /**
    * Make a post in chunked mode
    *
    * @throws Exception


### PR DESCRIPTION
This is a one-method addition to allow for sending a json body in the request. It doesn't add any dependencies since the signature just takes the stringified json.
