### PR TITLE
Fix #126

### DIFF
--- a/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
+++ b/lib/src/main/java/com/github/kevinsawicki/http/HttpRequest.java
@@ -2938,8 +2938,10 @@ public class HttpRequest {
       writePartHeader(name, filename, contentType);
       copy(part, output);
     } catch (IOException e) {
+      try { part.close(); } catch (IOException ioe) {} //when Connection timed out, close the file silently
       throw new HttpRequestException(e);
     }
+
     return this;
   }
 


### PR DESCRIPTION
When using part method and a ConnectException is thrown, then the inputStream used by the part method is not closed.
