### PR TITLE
Fixing flaky tests by resetting ConnectionFactory

### DIFF
--- a/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
+++ b/lib/src/test/java/com/github/kevinsawicki/http/HttpRequestTest.java
@@ -3477,6 +3477,7 @@ public class HttpRequestTest extends ServerTestCase {
     HttpRequest.setConnectionFactory(factory);
     int code = get("http://not/a/real/url").code();
     assertEquals(200, code);
+    HttpRequest.setConnectionFactory(null);
   }
 
   /**


### PR DESCRIPTION
Tests in com.github.kevinsawicki.http.HttpRequestTest fail when run after test HttpRequestTest.customConnectionFactory. customConnectionFactory sets the ConnectionFactory instance in HttpRequest to a custom one but fails to reset it back to the default. Later tests, such as postWithVaragsQueryParams, expect the ConnectionFactory to be the default. This proposed fix resets the ConnectionFactory to the default after customConnectionFactory is run.